### PR TITLE
Instalar y configurar pipenv y pylint

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -24,9 +24,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
+      uses: dschep/install-pipenv-action@v1
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pipenv install
     - name: Run Tests
       run: |
-        python manage.py test
+        pipenv run test

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,12 +20,11 @@ jobs:
       with:
         python-version: 3.8
     - name: Install dependencies
+      uses: dschep/install-pipenv-action@v1
       run: |
-        python -m pip install --upgrade pip
-        pip install pylint pylint-django
-        pip install -r requirements.txt
+        pipenv install --dev
     - name: Analysing the code with pylint
       env:
         DJANGO_SETTINGS_MODULE: balneario.settings
       run: |
-        pylint --disable=C0111 --load-plugins pylint_django backend balneario
+        pipenv run lint

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,4 +2,4 @@
 load-plugins=pylint_django
 
 [MESSAGES CONTROL]
-disable=C0111,R0901
+disable=C0111,R0901,W0221

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MASTER]
+load-plugins=pylint_django
+
+[MESSAGES CONTROL]
+disable=C0111,R0901

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [scripts]
 manage = "python manage.py"
 runserver = "python manage.py runserver"
-lint = "pylint --load-plugins pylint_django --disable=C0111 balneario backend"
+lint = "pylint balneario backend"
 test = "python manage.py test"
 createsuperuser = "python manage.py createsuperuser"
 makemigrations = "python manage.py makemigrations"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,29 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[scripts]
+manage = "python manage.py"
+runserver = "python manage.py runserver"
+lint = "pylint --load-plugins pylint_django --disable=C0111 balneario backend"
+test = "python manage.py test"
+createsuperuser = "python manage.py createsuperuser"
+makemigrations = "python manage.py makemigrations"
+migrate = "python manage.py migrate"
+
+[dev-packages]
+pylint-django = "*"
+
+[packages]
+asgiref = "==3.2.10"
+django-cors-headers = "==3.5.0"
+djangorestframework = "==3.11.1"
+djangorestframework-simplejwt = "==4.4.0"
+pytz = "==2020.1"
+sqlparse = "==0.3.1"
+Django = "==3.1"
+PyJWT = "==1.7.1"
+
+[requires]
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,188 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "40f22e97a2d9762ba1ec999299e7f9eb9da4691e991d463f4790d6530801fd91"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:7e51911ee147dd685c3c8b805c0ad0cb58d360987b56953878f8c06d2d1c6f1a",
+                "sha256:9fc6fb5d39b8af147ba40765234fa822b39818b12cc80b35ad9b0cef3a476aed"
+            ],
+            "index": "pypi",
+            "version": "==3.2.10"
+        },
+        "django": {
+            "hashes": [
+                "sha256:1a63f5bb6ff4d7c42f62a519edc2adbb37f9b78068a5a862beff858b68e3dc8b",
+                "sha256:2d390268a13c655c97e0e2ede9d117007996db692c1bb93eabebd4fb7ea7012b"
+            ],
+            "index": "pypi",
+            "version": "==3.1"
+        },
+        "django-cors-headers": {
+            "hashes": [
+                "sha256:9322255c296d5f75089571f29e520c83ff9693df17aa3cf9f6a4bea7c6740169",
+                "sha256:db82b2840f667d47872ae3e4a4e0a0d72fbecb42779b8aa233fa8bb965f7836a"
+            ],
+            "index": "pypi",
+            "version": "==3.5.0"
+        },
+        "djangorestframework": {
+            "hashes": [
+                "sha256:6dd02d5a4bd2516fb93f80360673bf540c3b6641fec8766b1da2870a5aa00b32",
+                "sha256:8b1ac62c581dbc5799b03e535854b92fc4053ecfe74bad3f9c05782063d4196b"
+            ],
+            "index": "pypi",
+            "version": "==3.11.1"
+        },
+        "djangorestframework-simplejwt": {
+            "hashes": [
+                "sha256:288ee78618d906f26abf6282b639b8f1806ce1d9a7578897a125cf79c609f259",
+                "sha256:c315be70aa12a5f5790c0ab9acd426c3a58eebea65a77d0893248c5144a5080c"
+            ],
+            "index": "pypi",
+            "version": "==4.4.0"
+        },
+        "pyjwt": {
+            "hashes": [
+                "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
+                "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"
+            ],
+            "index": "pypi",
+            "version": "==1.7.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
+            ],
+            "index": "pypi",
+            "version": "==2020.1"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
+                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
+            ],
+            "index": "pypi",
+            "version": "==0.3.1"
+        }
+    },
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
+                "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.4.2"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.3"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:6187a9f1ce8784cbc6d1b88790a43e6083a6302f03e9ae482acc0f232a98c843",
+                "sha256:c16eaa7432a1c004c585d79b12ad080c6c421dd18fe27982ca11f95e6898e432"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "version": "==5.5.3"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.4.3"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210",
+                "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.6.0"
+        },
+        "pylint-django": {
+            "hashes": [
+                "sha256:770e0c55fb054c6378e1e8bb3fe22c7032a2c38ba1d1f454206ee9c6591822d7",
+                "sha256:b8dcb6006ae9fa911810aba3bec047b9410b7d528f89d5aca2506b03c9235a49"
+            ],
+            "index": "pypi",
+            "version": "==2.3.0"
+        },
+        "pylint-plugin-utils": {
+            "hashes": [
+                "sha256:2f30510e1c46edf268d3a195b2849bd98a1b9433229bb2ba63b8d776e1fc4d0a",
+                "sha256:57625dcca20140f43731311cd8fd879318bf45a8b0fd17020717a8781714a25a"
+            ],
+            "version": "==0.6"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+            ],
+            "version": "==0.10.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
+            ],
+            "version": "==1.12.1"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Balneario es una app web para administrar reservas en un balneario.
 
 ## Instalación
 
-Use ```pip``` para instalar las dependencias necesarias para el backend.
+Use ```pipenv``` para instalar las dependencias necesarias para el backend.
 
 ```
-pip install -r requirements.txt
+pip install --user pipenv
+pipenv install --dev
 ```
 
 Use ```npm``` para instalar las dependencias necesarias para el frontend.
@@ -25,13 +26,10 @@ npm i
 Ejecutar las migraciones desde la raiz del proyecto.
 
 ```
-python manage.py makemigrations
-python manage.py migrate
+pipenv run migrate
 ```
 
-Debe ejecutarse cada vez que algun modelo es cambiado.
-
 ## Uso
-1. Compilar el frontend ejecutando ```ng build``` desde la carpeta frontend/angularapp.
-2. Desde la raiz del proyecto ejecutar ```python manage.py runserver```.
-3. Acceder desde http://localhost:8000/acceso.
+1. Iniciar el frontend ejecutando ```ng serve``` desde la carpeta frontend/angularapp.
+2. Desde la raiz del proyecto ejecutar ```pipenv run runserver```.
+3. Acceder desde http://localhost:4200/.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-asgiref==3.2.10
-Django==3.1
-django-cors-headers==3.5.0
-djangorestframework==3.11.1
-djangorestframework-simplejwt==4.4.0
-PyJWT==1.7.1
-pytz==2020.1
-sqlparse==0.3.1


### PR DESCRIPTION
Permite mejor administracion de paquetes y configurar acciones como con `npm`.

Para instalar las dependencias se ejecuta `pipenv install --dev`.

Con `pipenv shell` se activa el entorno, igualmente hay acciones comunes de Django configuradas como:

- `pipenv run runserver`
- `pipenv run makemigrations`
- `pipenv run migrate`

El resto se encuentra en la seccion scripts del Pipfile.

Tambien se pueden verificar errores de codigo con `pipenv run lint`.